### PR TITLE
Refactor: 탑버튼 재구현(임시)

### DIFF
--- a/src/components/DetailSectionTop/DetailTopButton.tsx
+++ b/src/components/DetailSectionTop/DetailTopButton.tsx
@@ -1,41 +1,51 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { TopIcon } from '@components/common/icons/Icons';
 
-export default function DetailTopButton() {
-  const [showButton, setShowButton] = useState(true);
+export default function DetailTopButton({ parentRef }: any) {
+  const [isVisible, setIsVisible] = useState<boolean>(false);
+  const [scrollPosition, setScrollPosition] = useState<number>(0);
+  const [viewportHeight, setViewportHeight] = useState<number>(0);
 
-  const scrollToTop = () => {
-    window.scroll({
-      top: 0,
-      behavior: 'smooth',
-    });
-  };
+  const scrollButtonRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    const handleShowButton = () => {
-      if (window.scrollY > 400) {
-        setShowButton(true);
-      } else {
-        setShowButton(false);
+    const handleScroll = () => {
+      if (scrollButtonRef.current && parentRef.current) {
+        setViewportHeight(screen.height);
+
+        // 부모 요소의 높이보다 적을 때까지 스크롤 허용
+        if (window.scrollY < parentRef.current.clientHeight - 50) {
+          // 기기 높이의 절반 이상 스크롤 했을 때
+          if (window.scrollY >= viewportHeight / 2) {
+            setIsVisible(true);
+            setScrollPosition(window.scrollY);
+          } else {
+            setIsVisible(false);
+          }
+        }
       }
     };
 
-    window.addEventListener('scroll', handleShowButton);
+    window.addEventListener('scroll', handleScroll);
 
     return () => {
-      window.removeEventListener('scroll', handleShowButton);
+      window.removeEventListener('scroll', handleScroll);
     };
-  }, []);
+  }, [parentRef, scrollPosition, setScrollPosition]);
+
+  const scrollToTop = () => {
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  };
 
   return (
-    showButton && (
-      <div
-        onClick={scrollToTop}
-        className="scroll__container sticky bottom-3 z-20 flex cursor-pointer items-center justify-end">
-        <div className="flex h-12 w-12 items-center justify-center rounded-full bg-white shadow-md">
-          <TopIcon />
-        </div>
-      </div>
-    )
+    <div
+      ref={scrollButtonRef}
+      className={`absolute right-2 flex h-12 w-12 cursor-pointer items-center justify-center rounded-full bg-white shadow-md transition-opacity duration-500 ${
+        isVisible ? 'opacity-100' : 'opacity-0'
+      }`}
+      onClick={scrollToTop}
+      style={{ top: `${scrollPosition}px` }}>
+      <TopIcon />
+    </div>
   );
 }

--- a/src/components/common/icons/Icons.tsx
+++ b/src/components/common/icons/Icons.tsx
@@ -995,8 +995,8 @@ export const TopIcon: React.FC<IconProps> = () => {
       xmlns="http://www.w3.org/2000/svg">
       <path
         id="Vector 734 (Stroke)"
-        fill-rule="evenodd"
-        clip-rule="evenodd"
+        fillRule="evenodd"
+        clipRule="evenodd"
         d="M17.0462 8.95185C16.7278 9.30213 16.1857 9.32794 15.8354 9.00951L8.86914 2.67653L1.90286 9.00951C1.55258 9.32794 1.01048 9.30213 0.692049 8.95185C0.373615 8.60157 0.39943 8.05947 0.749708 7.74104L8.86914 0.359741L16.9886 7.74104C17.3388 8.05947 17.3647 8.60157 17.0462 8.95185Z"
         fill="#888888"
       />

--- a/src/pages/detail/detail.page.tsx
+++ b/src/pages/detail/detail.page.tsx
@@ -1,16 +1,21 @@
 import { DetailHeader } from '@components/common/header';
 import DetailSectionTop from '@components/DetailSectionTop/DetailSectionTop';
 import DetailSectionBottom from '@components/DetailSectionBottom/DetailSectionBottom';
-// import { DetailTopButton } from '@components/DetailSectionTop';
+import { DetailTopButton } from '@components/DetailSectionTop';
+import { useRef } from 'react';
 
 const DetailTours = () => {
+  const parentRef = useRef<HTMLDivElement>(null);
+
   return (
-    <>
+    <div>
       <DetailHeader />
       <DetailSectionTop />
-      <DetailSectionBottom />
-      {/* <DetailTopButton /> */}
-    </>
+      <div className="relative" ref={parentRef}>
+        <DetailSectionBottom />
+        <DetailTopButton parentRef={parentRef} />
+      </div>
+    </div>
   );
 };
 


### PR DESCRIPTION
📌 **작업 내용**

기존 탑버튼(sticky 사용)에서 useRef + absolute 형식으로 변경

📌 **확인 사항**

미적용
* sticky - 리뷰 하단 여백 생겨서 안됨(무조건 공간이 생긴다고 합니다)
* fixed - 반응형이 아닌 모바일 웹앱이라 안됨(부모가 무조건 viewport 기준이라 사용 안된다고 합니다)

적용
* absolute - top 값을 동적으로 이동시키는 방식으로 변경

디바이스별 높이값이 달라서 디바이스별로 버튼이 하단에서 띄워진 높이 값이 다른데, 이 부분을 도저히 해결하지 못했습니다...
+ 412px 이상에서는 fixed 사용(레이아웃 바깥 버튼)하고, 이하에서는 absolute 사용하는 방안도 생각해봤는데 어떠신가요?

* 머지 안해주셔도 됩니다
